### PR TITLE
use mapcar instead of loop macro to remove CL package dependency

### DIFF
--- a/dash-at-point.el
+++ b/dash-at-point.el
@@ -105,7 +105,10 @@ for one or more docsets in Dash."
   :group 'dash-at-point)
 
 ;;;###autoload
-(defvar dash-at-point-docsets (loop for (key . value) in dash-at-point-mode-alist collect value)
+(defvar dash-at-point-docsets (mapcar
+                               (lambda (element)
+                                 (cdr element))
+                               dash-at-point-mode-alist)
   "Variable used to store all known Dash docsets. The default value
 is a collection of all the values from `dash-at-point-mode-alist'.
 


### PR DESCRIPTION
dash-at-point initialization currently errors if user hasn't included the CL package with `(require 'cl)`
