### PR TITLE
Support enh-ruby-mode and tcl-mode

### DIFF
--- a/dash-at-point.el
+++ b/dash-at-point.el
@@ -76,6 +76,7 @@
     (css-mode . "css")
     (elixir-mode . "elixir")
     (emacs-lisp-mode . "elisp")
+    (enh-ruby-mode . "ruby")
     (erlang-mode . "erlang")
     (gfm-mode . "markdown")
     (go-mode . "go")
@@ -97,6 +98,7 @@
     (ruby-mode . "ruby")
     (sass-mode . "sass")
     (scala-mode . "scala")
+    (tcl-mode . "tcl")
     (vim-mode . "vim"))
   "Alist which maps major modes to Dash docset tags.
 Each entry is of the form (MAJOR-MODE . DOCSET-TAG) where


### PR DESCRIPTION
[enh-ruby-mode](https://github.com/zenspider/enhanced-ruby-mode) is another major mode for Ruby.
