### PR TITLE
remove namespace from symbol before sending to dash

### DIFF
--- a/dash-at-point.el
+++ b/dash-at-point.el
@@ -231,12 +231,11 @@ If the optional prefix argument EDIT-SEARCH is specified,
 the user will be prompted to edit the search string first."
   (interactive "P")
   (let* ((thing (thing-at-point 'symbol))
-	 (docset (or dash-at-point-docset (dash-at-point-guess-docset))))
-    (dash-at-point-run-search
-     (if (or edit-search (null thing))
-         (read-string "Dash search: " thing)
-       thing)
-     docset)))
+         (search (if (or edit-search (null thing))
+                     (read-string "Dash search: " thing)
+                   (car (last (split-string thing "/")))))
+         (docset (or dash-at-point-docset (dash-at-point-guess-docset))))
+    (dash-at-point-run-search search docset)))
 
 ;;;###autoload
 (defun dash-at-point-with-docset (&optional edit-search)
@@ -253,7 +252,7 @@ choosing the docset."
 				  nil nil nil 'minibuffer-history (dash-at-point-guess-docset)))
          (search (if (or edit-search (null thing))
                      (read-from-minibuffer (concat "Dash search (" docset "): "))
-                   thing)))
+                   (car (last (split-string thing "/"))))))
     (dash-at-point-run-search search docset)))
 
 (provide 'dash-at-point)


### PR DESCRIPTION
Removes the namespace qualifier from the search string before sending to dash. For example, if you required `clojure.string :as string` and then use `string/join` in your code, when you hit _Ctrl-c,d_, it'll search for `join` in _clojure_ docset (instead of searching for `string/join`, which doesn't return any results).

It's a very basic fix (the proper fix will need to use cider's functions to resolve the _thing-at-point_ to canonised form), but it works.
