### PR TITLE
Open dash without activating it

### DIFF
--- a/dash-at-point.el
+++ b/dash-at-point.el
@@ -213,7 +213,7 @@ the combined docset.")
 
 (defun dash-at-point-run-search (search-string &optional docset)
   "Directly execute search for SEARCH-STRING in Dash."
-  (start-process "Dash" nil "open"
+  (start-process "Dash" nil "open" "-g"
 		 (if dash-at-point-legacy-mode
 		     (concat "dash://"
 			     (when docset


### PR DESCRIPTION
Pass "-g" option to `open` command.

Closes #21.