### PR TITLE
Update the MELPA URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Dash 1.9.3 introduces a new way to call Dash with keywords (`dash-plugin://`), b
 (custom-set-variables '(dash-at-point-legacy-mode t))
 ```
 
-[melpa]: http://melpa.milkbox.net
+[melpa]: https://melpa.org
 
 # Copyright
 


### PR DESCRIPTION
This patch does one thing and one thing only: update the MELPA URL from “http://melpa.milkbox.net” to “https://melpa.org”.